### PR TITLE
Inline use of `unsafePromote`

### DIFF
--- a/src/Jack/Gen.purs
+++ b/src/Jack/Gen.purs
@@ -12,8 +12,10 @@ module Jack.Gen (
 import Control.Lazy (class Lazy, defer)
 
 import Data.List.Lazy as Lazy
+import Data.Tuple (Tuple(..))
 
-import Jack.Random (Random, unsafePromote)
+import Jack.Random (Random(..), runRandom)
+import Jack.Seed (Seed, splitSeed)
 import Jack.Tree (Tree, unfoldTree, expandTree)
 
 import Prelude
@@ -77,12 +79,31 @@ instance applicativeGen :: Applicative Gen where
 instance bindGen :: Bind Gen where
   bind m0 k0 =
     let
-      go :: forall a b. Random (Tree a) -> (a -> Random (Tree b)) -> Random (Tree b)
-      go m k =
-        bind m \ta ->
-          map join <<< unsafePromote $ map k ta
+      bindRandom :: forall a b. Random (Tree a) -> (a -> Random (Tree b)) -> Random (Tree b)
+      bindRandom randomA k =
+        Random \seed0 size ->
+          case splitSeed seed0 of
+            Tuple seed1 seed2 ->
+              let
+                run :: forall x. Seed -> Random x -> x
+                run seed random =
+                  runRandom seed size random
+
+                treeA :: Tree a
+                treeA =
+                  run seed1 randomA
+
+                treeRandomsB :: Tree (Random (Tree b))
+                treeRandomsB =
+                  map k treeA
+
+                treesB :: Tree (Tree b)
+                treesB =
+                  map (run seed2) treeRandomsB
+              in
+                join treesB
     in
-      Gen $ go (runGen m0) (runGen <<< k0)
+      Gen $ bindRandom (runGen m0) (runGen <<< k0)
 
 instance monadGen :: Monad Gen
 

--- a/src/Jack/Random.purs
+++ b/src/Jack/Random.purs
@@ -9,8 +9,6 @@ module Jack.Random (
   , chooseInt
 
   -- ** Unsafe
-  , unsafeDelay
-  , unsafePromote
   , unsafeChooseInt53
 
   -- ** Utils
@@ -44,15 +42,6 @@ newtype Random a =
 runRandom :: forall a. Seed -> Size -> Random a -> a
 runRandom seed size (Random r) =
   r seed size
-
-unsafeDelay :: forall a. Random (Random a -> a)
-unsafeDelay =
-  Random runRandom
-
-unsafePromote :: forall m a. Functor m => m (Random a) -> Random (m a)
-unsafePromote m = do
-  eval <- unsafeDelay
-  pure $ map eval m
 
 -- | Used to construct generators that depend on the size parameter.
 sized :: forall a. (Size -> Random a) -> Random a


### PR DESCRIPTION
The previous implementation using `unsafePromote` was pretty much the same, but it was splitting the seed more than necessary, so `<*>` was different to `ap`, which probably didn't matter that much, but it's nice to have them be the same.

We still have the issue that `pure f <*> x` is not the same as `f <$> x`, we could probably fix that by implementing `map` using `bind`, and thereby splitting unnecessarily, not sure if that's a good idea or not, it would mean `map id g /= g`.

I'm not sure that you can win with this splittable generator stuff, but it probably doesn't matter in practice as the differences aren't observable unless you pass a specific seed to a generator.

In any case, I think it's easier to understand how bind for `Gen` actually works with the new structure.

/cc @charleso
