### PR TITLE
Compile via spago

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,7 @@
 /output/
 /.psci*
 /src/.webpack.js
+/.spago/*
+/.psc*
+/.purs*
+/generated-docs/*

--- a/packages.dhall
+++ b/packages.dhall
@@ -1,0 +1,134 @@
+{-
+Welcome to your new Dhall package-set!
+
+Below are instructions for how to edit this file for most use
+cases, so that you don't need to know Dhall to use it.
+
+## Warning: Don't Move This Top-Level Comment!
+
+Due to how `dhall format` currently works, this comment's
+instructions cannot appear near corresponding sections below
+because `dhall format` will delete the comment. However,
+it will not delete a top-level comment like this one.
+
+## Use Cases
+
+Most will want to do one or both of these options:
+1. Override/Patch a package's dependency
+2. Add a package not already in the default package set
+
+This file will continue to work whether you use one or both options.
+Instructions for each option are explained below.
+
+### Overriding/Patching a package
+
+Purpose:
+- Change a package's dependency to a newer/older release than the
+    default package set's release
+- Use your own modified version of some dependency that may
+    include new API, changed API, removed API by
+    using your custom git repo of the library rather than
+    the package set's repo
+
+Syntax:
+Replace the overrides' "{=}" (an empty record) with the following idea
+The "//" or "⫽" means "merge these two records and
+  when they have the same value, use the one on the right:"
+-------------------------------
+let overrides =
+  { packageName =
+      upstream.packageName // { updateEntity1 = "new value", updateEntity2 = "new value" }
+  , packageName =
+      upstream.packageName // { version = "v4.0.0" }
+  , packageName =
+      upstream.packageName // { repo = "https://www.example.com/path/to/new/repo.git" }
+  }
+-------------------------------
+
+Example:
+-------------------------------
+let overrides =
+  { halogen =
+      upstream.halogen // { version = "master" }
+  , halogen-vdom =
+      upstream.halogen-vdom // { version = "v4.0.0" }
+  }
+-------------------------------
+
+### Additions
+
+Purpose:
+- Add packages that aren't already included in the default package set
+
+Syntax:
+Replace the additions' "{=}" (an empty record) with the following idea:
+-------------------------------
+let additions =
+  { package-name =
+       { dependencies =
+           [ "dependency1"
+           , "dependency2"
+           ]
+       , repo =
+           "https://example.com/path/to/git/repo.git"
+       , version =
+           "tag ('v4.0.0') or branch ('master')"
+       }
+  , package-name =
+       { dependencies =
+           [ "dependency1"
+           , "dependency2"
+           ]
+       , repo =
+           "https://example.com/path/to/git/repo.git"
+       , version =
+           "tag ('v4.0.0') or branch ('master')"
+       }
+  , etc.
+  }
+-------------------------------
+
+Example:
+-------------------------------
+let additions =
+  { benchotron =
+      { dependencies =
+          [ "arrays"
+          , "exists"
+          , "profunctor"
+          , "strings"
+          , "quickcheck"
+          , "lcg"
+          , "transformers"
+          , "foldable-traversable"
+          , "exceptions"
+          , "node-fs"
+          , "node-buffer"
+          , "node-readline"
+          , "datetime"
+          , "now"
+          ]
+      , repo =
+          "https://github.com/hdgarrood/purescript-benchotron.git"
+      , version =
+          "v7.0.0"
+      }
+  }
+-------------------------------
+-}
+
+
+let upstream =
+      https://github.com/purescript/package-sets/releases/download/psc-0.13.6-20200309/packages.dhall sha256:9221987b4e7ea99ccd0efbe056f7bebc872cd92e0058efe5baa181d73359e7b3
+
+let overrides = {=}
+
+let additions =
+  { int-53 =
+    { dependencies = [ "math", "integers", "strings" ]
+    , repo = "https://github.com/rgrempel/purescript-int-53.git"
+    , version = "master"
+    }
+  }
+
+in  upstream // overrides // additions

--- a/spago.dhall
+++ b/spago.dhall
@@ -1,0 +1,22 @@
+{-
+Welcome to a Spago project!
+You can edit this file as you like.
+-}
+{ name = "jack"
+, dependencies =
+  [ "arrays"
+  , "console"
+  , "effect"
+  , "foldable-traversable"
+  , "foreign-object"
+  , "generics-rep"
+  , "int-53"
+  , "lists"
+  , "prelude"
+  , "psci-support"
+  , "random"
+  , "strings"
+  ]
+, packages = ./packages.dhall
+, sources = [ "src/**/*.purs", "test/**/*.purs" ]
+}

--- a/src/Jack/Runner.js
+++ b/src/Jack/Runner.js
@@ -3,7 +3,9 @@
 exports.findProperties = function (module) {
   return function () {
     var properties = {};
-    var exports = require(module);
+    // Using `require(module);` won't find the correct module
+    // By appending `../` to its front, it'll find the correct module.
+    var exports = require("../" + module);
 
     for (var name in exports) {
       if (name.startsWith("prop_")) {


### PR DESCRIPTION
Updates this library to
- use Spago as its dependency manager and build tool
- fixes module discovery via FFI by appending "../" in front of the module name

Note: the `master` branch of `purescript-int-53` is used because there's not a later release that include the commit that adds "purescript-strings' as a dependency.